### PR TITLE
In order to resolve NDEX-405, we need to make sure that all projects use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ndexbio.org</groupId>
 	<artifactId>ndex-sync</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>1.0.0</version>
 	<name>NDEx Synchronization Application</name>
 	<description>Application to synchronize networks between NDEx Server instances</description>
 	<dependencies>
@@ -12,13 +12,18 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.2.2</version>
+			<version>2.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.2.2</version>
+			<version>2.5.2</version>
 		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.2</version>
+        </dependency>
 
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -33,7 +38,7 @@
 		<dependency>
 			<groupId>org.ndexbio.client</groupId>
 			<artifactId>ndex-java-client</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>1.0.0</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
the same version of Jackson library (2.5.2).  So we update the 
pom file to use Jackson 2.5.2.  Also, we nake sure that ndex-sync uses
client release 1.0.0.
