### PR TITLE
Modified the behavior of the copier:  if the latest event in provenance

### DIFF
--- a/src/main/java/org/ndexbio/sync/CopyPlan.java
+++ b/src/main/java/org/ndexbio/sync/CopyPlan.java
@@ -261,10 +261,10 @@ public abstract class CopyPlan implements NdexProvenanceEventType {
                 // configuration parameter.  To check if target is read-only, if (targetCandidate.getReadOnlyCommitId() > 0).
                     
     	    	if ((targetCandidate.getReadOnlyCommitId() > 0) && (false == updateReadOnlyNetwork)) {
-    	     	   // the target is read-only and updateReadOnlyNetwork config parameter is false, don't update target
-    				LOGGER.info("Target network " + targetCandidate.getExternalId() + " is read-only and updateReadOnlyNetwork is false. Not updating target and not copying to target.");
+    	     	    // the target is read-only and updateReadOnlyNetwork config parameter is false, don't update target
+    				LOGGER.info("Target network " + targetCandidate.getExternalId() + " is read-only and updateReadOnlyNetwork is false. Not updating target.");
                     	
-    				copySourceNetwork = false;             	
+    				//copySourceNetwork = false;             	
                     continue;  // get next target network
     	    	}
     				


### PR DESCRIPTION
is not COPY, then do not traverse provenance from the latest (most
recent) event back to the very first one in search of the latest (most
recent) COPY trying to figure out whether we need to copy the source
network to target or not.
If the latest event is not COPY, we assume that default behavior is to
copy the network in update mode, unless the target network needs to be
replaced or both source and target network are synchronized.
